### PR TITLE
2.0 upm

### DIFF
--- a/Runtime/XChartsMgr.cs
+++ b/Runtime/XChartsMgr.cs
@@ -57,7 +57,9 @@ namespace XCharts
                     {
                         var obj = GameObject.Find("_xcharts_");
                         if (obj == null) obj = new GameObject("_xcharts_");
+                        obj.SetActive(false);
                         m_XCharts = obj.AddComponent<XChartsMgr>();
+                        obj.SetActive(true);
                     }
                     m_XCharts.m_NowVersion = fullVersion;
                 }


### PR DESCRIPTION
修复因XChartsMgr不存在，而创建新对象时导致的死循环问题。
由于Awake会在组件被创建时同步执行一次，而在执行Awake时m_XCharts并没有被赋值，所以导致死循环。
让对象处于关闭状态，添加组件时就不会同步执行Awake方法，而是延迟到下一次开启对象时执行。
在下一次开启对象时，m_XCharts已经被赋值，所以不会导致死循环问题。
死循环发生在Awake时调用XThemeMgr.ReloadThemeList，而ReloadThemeList方法中有调用了实例。