### PR TITLE
修复Serie名中包含下划线时,会导致Legend组件无法点击的问题

### DIFF
--- a/Runtime/Component/Legend/LegendHandler.cs
+++ b/Runtime/Component/Legend/LegendHandler.cs
@@ -99,7 +99,7 @@ namespace XCharts.Runtime
                     ChartHelper.AddEventListener(item.button.gameObject, EventTriggerType.PointerDown, (data) =>
                     {
                         if (data.selectedObject == null || legend.selectedMode == Legend.SelectedMode.None) return;
-                        var temp = data.selectedObject.name.Split('_');
+                        var temp = data.selectedObject.name.Split('_', 2);
                         string selectedName = temp[1];
                         int clickedIndex = int.Parse(temp[0]);
                         if (legend.selectedMode == Legend.SelectedMode.Multiple)
@@ -117,7 +117,7 @@ namespace XCharts.Runtime
                             {
                                 for (int n = 0; n < btnList.Length; n++)
                                 {
-                                    temp = btnList[n].name.Split('_');
+                                    temp = btnList[n].name.Split('_', 2);
                                     selectedName = btnList[n].legendName;
                                     var index = btnList[n].index;
                                     OnLegendButtonClick(legend, n, selectedName, index == clickedIndex ? true : false);
@@ -128,7 +128,7 @@ namespace XCharts.Runtime
                     ChartHelper.AddEventListener(item.button.gameObject, EventTriggerType.PointerEnter, (data) =>
                     {
                         if (item.button == null) return;
-                        var temp = item.button.name.Split('_');
+                        var temp = item.button.name.Split('_', 2);
                         string selectedName = temp[1];
                         int index = int.Parse(temp[0]);
                         OnLegendButtonEnter(legend, index, selectedName);
@@ -136,7 +136,7 @@ namespace XCharts.Runtime
                     ChartHelper.AddEventListener(item.button.gameObject, EventTriggerType.PointerExit, (data) =>
                     {
                         if (item.button == null) return;
-                        var temp = item.button.name.Split('_');
+                        var temp = item.button.name.Split('_', 2);
                         string selectedName = temp[1];
                         int index = int.Parse(temp[0]);
                         OnLegendButtonExit(legend, index, selectedName);


### PR DESCRIPTION
由于实现方法是index和name使用下划线合并到物体名称中, 之后在接受事件时用下划线分割后获取index和name. 导致name中包含下划线时会被分割.
修改限制分割为2部分
#259 